### PR TITLE
Update 03-styles instruction text

### DIFF
--- a/training/03-styles.md
+++ b/training/03-styles.md
@@ -108,7 +108,7 @@ Lots of core blocks come with styles. Depending on the client, the design, or th
 ### Steps (These steps have already been done for you. Please follow along as a reference.)
 
 1. Create a new `pullquote.js` file in `/includes/block-styles/`
-2. Use the `unRegisterBlockStyle` function to select the `core/pullquote` block, and remove the "Solid color" style.
+2. Use the `unregisterBlockStyle` function to select the `core/pullquote` block, and remove the "Solid color" style.
 3. Import your `pullquote.js` into `/includes/block-styles/index.js`
 
 After we've done that, we can see that the "Solid color" Style has now been removed:


### PR DESCRIPTION
### Description of the Change
Updated the style instructions to clarify where the style classname comes from (e.g. it is created with the prefix of `is-style-` plus whatever the name of the style is). 

**Motivation**
When I was going through this training I was very confused at this part. The instructions seemed to indicate I was supposed to provide the class name instead of it being inferred by the block style config. 

I feel like the above is a small way to make the instructions a bit more obvious and maybe help someone else who gets confused by this.

### Changelog Entry

Changed - Updated Lesson 3 instructions for additional clarity on how the block style classname is added.
