### PR TITLE
Fix text nitpicks

### DIFF
--- a/reference/01-Fundamentals/a-block.md
+++ b/reference/01-Fundamentals/a-block.md
@@ -77,7 +77,7 @@ A block may exist in several different states in the editor. Depending on what s
 
 The initial setup state is one that not all blocks will or even should have. But it is a common pattern that gets used whenever a block relies on a core piece of data before it can start displaying it's main interface.
 
-A great examples of this in the core blocks for example is the cover block. The cover relies on a background image or some background color. When neither of the two is selected there is not much you can do with the block. Therefore it presents you with a placeholder to select a background image or color and once you have completed this step you are not represented with all the options.
+A great examples of this in the core blocks for example is the cover block. The cover relies on a background image or some background color. When neither of the two is selected there is not much you can do with the block. Therefore it presents you with a placeholder to select a background image or color and once you have completed this step you are represented with all the options.
 
 This pattern of having a placeholder also allows you to make it easier for your editors in very complex block to not overwhelm them when they start inserting the block. If you look at the core columns block the first thing you get to see is a placeholder where you can select the layout of columns you want to start with. You can of course change that easily later in the settings sidebar but you don't need to and can get up and running without having to interact with the advanced options in the sidebar at all.
 

--- a/reference/02-Themes/styles.md
+++ b/reference/02-Themes/styles.md
@@ -23,7 +23,7 @@ function theme_setup() {
 add_action( 'after_setup_theme', 'theme_setup' );
 ```
 
-The stylesheets that get added via the `add_editor_style` function get automatically parsed by WordPress and get scoped to the `.editor-styles-wrapper` class. This means that you cannot target anything outside of the `.editor-styles-wrapper` in that stylesheet since core will override that. The transformed parsed and transformed stylesheet then gets inlined in the editor.
+The stylesheets that get added via the `add_editor_style` function get automatically parsed by WordPress and get scoped to the `.editor-styles-wrapper` class. This means that you cannot target anything outside of the `.editor-styles-wrapper` in that stylesheet since core will override that. The parsed and transformed stylesheet then gets inlined in the editor.
 
 :::tip
 If you need to load custom fonts from an external source you also need to add a separate `add_editor_style` call for the stylesheet loading the font.

--- a/reference/03-Blocks/block-patterns.md
+++ b/reference/03-Blocks/block-patterns.md
@@ -153,4 +153,4 @@ There is one item that you need to be aware about in regards to Block Patterns. 
 
 If you find an issue with the markup of a pattern that you want to fix it is only going to impact new instances of the pattern that are created after you updated it. And you will have to manually go into every instance that was created using the pattern and make the update manually, or create an update script to update it in the database directly.
 
-If you want to get around this limitation you can of course also build block patterns mad up of [custom-blocks](./custom-blocks) that don't actually store their markup in the database. That way you can get the benefits of both worlds.
+If you want to get around this limitation you can of course also build block patterns made up of [custom-blocks](./custom-blocks) that don't actually store their markup in the database. That way you can get the benefits of both worlds.

--- a/reference/03-Blocks/block-styles.md
+++ b/reference/03-Blocks/block-styles.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Block Styles
 
-Block styles are a relatively simple API that allows you to add different visual styles to a block. In Core the image for example allows you to select a rounded style to round the corners of the image.
+Block styles are a relatively simple API that allows you to add different visual styles to a block. In Core, the image block, for example allows you to select a rounded style to round the corners of the image.
 
 !["Style Variations Picker within Gutenberg showing Default and Rounded as options"](/img/image-block-styles.png)
 
@@ -14,7 +14,7 @@ Block Styles come with many caveats though and should be used very sparingly. In
 
 ## User Experience
 
-In the editor styles are the first thing a user sees in the blocks setting sidebar. They are shown very prominently. So initially it seems like a great spot to place to put controls. This is only true as long as there are no more than 4 styles present. After that point the experience becomes too cluttered and overwhelming.
+In the editor, styles are the first thing a user sees in the blocks setting sidebar. They are shown very prominently. So initially it seems like a great spot to put controls. This is only true as long as there are no more than 4 styles present. After that point the experience becomes too cluttered and overwhelming.
 
 :::warning
 Additionally the style options have one fatal flaw. Only one of them can be active at a time. And most things that end up becoming styles are things that you down the line would love to combine. And that is a downfall that happens very quickly.


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR fixes the text nitpicks spotted while going through Gutenberg reference pages.
