### PR TITLE
Fix typo in block-extensions.md

### DIFF
--- a/reference/03-Blocks/block-extensions.md
+++ b/reference/03-Blocks/block-extensions.md
@@ -103,7 +103,7 @@ registerBlockExtension(
 | options.extensionName      | `string`   | Unique Identifier of the option added    |
 | options.attributes         | `object`   | Block Attributes that should get added to the block |
 | options.classNameGenerator | `function` | Function that gets passed the attributes of the block to generate a class name string |
-| options.Edit               | `function` | BlockEdit component like in `registerBlockType` only without the actual block. So onyl using slots like the `InspectorControls` is advised. |
+| options.Edit               | `function` | BlockEdit component like in `registerBlockType` only without the actual block. So only using slots like the `InspectorControls` is advised. |
 
 ## Manually using the hooks
 

--- a/reference/03-Blocks/block-extensions.md
+++ b/reference/03-Blocks/block-extensions.md
@@ -102,7 +102,7 @@ registerBlockExtension(
 | blockName                  | `string`   | Name of the block the options should get added to |
 | options.extensionName      | `string`   | Unique Identifier of the option added    |
 | options.attributes         | `object`   | Block Attributes that should get added to the block |
-| options.classNameGenerator | `function` | Funciton that gets passed the attributes of the block to generate a class name string |
+| options.classNameGenerator | `function` | Function that gets passed the attributes of the block to generate a class name string |
 | options.Edit               | `function` | BlockEdit component like in `registerBlockType` only without the actual block. So onyl using slots like the `InspectorControls` is advised. |
 
 ## Manually using the hooks


### PR DESCRIPTION
"Function" was spelled as "Funciton"
"Only" was spelled as "onyl"

<!-- Thanks for contributing to the 10up Gutenberg Best Practices! -->

## Description of the Change
This just fixes a minor typo
