### PR TITLE
Update broken GitHub reference

### DIFF
--- a/training/01-overview.md
+++ b/training/01-overview.md
@@ -159,7 +159,7 @@ function BlockEdit(props) {
 
 ```
 
-3. Finally, we output our `customTitle` attribute in our frontend markup in [markup.php](https://github.com/10up/wp-scaffold/blob/trunk/themes/tenup-theme/includes/blocks/example-block/markup.php#L31)!
+3. Finally, we output our `customTitle` attribute in our frontend markup in [markup.php](https://github.com/10up/wp-scaffold/blob/trunk/themes/10up-theme/includes/blocks/example-block/markup.php)!
 
 ```php title="markup.php" {2}
 <h2 <?php echo get_block_wrapper_attributes(); ?>>


### PR DESCRIPTION
The original link points to a 404 page for the previous tenup GitHub directory. This PR adds the correct GitHub page.

<!-- Thanks for contributing to the 10up Gutenberg Best Practices! -->

## Description of the Change
<!-- In a few words, what is the PR actually doing? -->

Closing #
