### PR TITLE
Unregister Block Example

### DIFF
--- a/reference/03-Blocks/block-locking.md
+++ b/reference/03-Blocks/block-locking.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 9
+---
 # Block Locking
 
 ![Block Locking UI](../../static/img/block-locking-ui.gif)

--- a/reference/03-Blocks/block-locking.md
+++ b/reference/03-Blocks/block-locking.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 9
 ---
+
 # Block Locking
 
 ![Block Locking UI](../../static/img/block-locking-ui.gif)

--- a/reference/03-Blocks/block-supports.md
+++ b/reference/03-Blocks/block-supports.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 8
 ---
 
 # Block Supports

--- a/reference/03-Blocks/block-transforms.md
+++ b/reference/03-Blocks/block-transforms.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 6
 ---
 
 # Block Transforms

--- a/reference/03-Blocks/block-updates.md
+++ b/reference/03-Blocks/block-updates.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 7
 ---
 
 # Block Updates

--- a/reference/03-Blocks/inner-blocks.md
+++ b/reference/03-Blocks/inner-blocks.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 5
 ---
 
 # Inner Blocks

--- a/reference/03-Blocks/unregister-block.md
+++ b/reference/03-Blocks/unregister-block.md
@@ -63,7 +63,9 @@ domReady(() => {
 ## Allow List:
 Opposite to the approach of `unregisterBlockType` would be to create a PHP allow list. In this scenario a developer would curate the specific blocks that they want to have shown to an editor. In these situations it is advised to always include common utility blocks such as: `core/block`, `core/missing`, `core/pattern`, `core/template-part` to prevent issues with the block editor. 
 
-**NOTE** - When using an allow list it is advised to review WordPress releases for any changes in existing blocks. As an example WordPress 6.1 refactored the list block from one singular block to an inner blocks structure with a list item. Anyone that used an allow list at that point needed to go in and update it to include the core/list-item block.
+:::caution
+When using an allow list it is advised to review WordPress releases for any changes in existing blocks. As an example WordPress 6.1 refactored the list block from one singular block to an inner blocks structure with a list item. Anyone that used an allow list at that point needed to go in and update it to include the core/list-item block.
+::::
 
 ## Code Example:
 ```php

--- a/reference/03-Blocks/unregister-block.md
+++ b/reference/03-Blocks/unregister-block.md
@@ -2,21 +2,21 @@
 sidebar_position: 10
 ---
 
-# Unregister a Block
+# Unregister a Block and Allow List
 
 ## Reference Guide WordPress Documentation:
 * [unregisterBlockType](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-blocks/#unregisterblocktype)
 
-## Use Case:
-Gutenberg comes with a lot of core blocks. When creating custom builds for clients all of these core blocks are generally not needed nor should they be used by the client. In these situations it is necessary to disable the blocks from the block editor so that a user can not access them when creating new pages and posts with the block editor. This can be done using the `unregisterBlockType` function and passing in the blocks which should be disallowed within a `.js` file. 
-
+## Unregister Use Case:
+Gutenberg comes with a lot of core blocks and this can be overwhelming for certain editors. Due to this situations arise where it is necessary to disable some blocks so that an editor can not access them when creating new pages and posts. Removing certain blocks can aid these editors by reducing cognitive load and confusion. This can be done using the `unregisterBlockType` function and passing in the blocks which should be disallowed within a `.js` file. 
 
 ## Code Example:
 This example showcases how an array of blocks can be passed into a single function and looped through to disable multiple blocks at the same time. 
 
 `block-filters/unregister-blocks.js`
 ```js
-import { unregisterBlockType } from '@wordpress/blocks';
+import domReady from '@wordpress/dom-ready';
+import { getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
 
 const disallowedBlocks = [
 	'core/preformatted',
@@ -30,7 +30,7 @@ const disallowedBlocks = [
 	'core/freeform',
 ];
 
-wp.domReady(() => {
+domReady(() => {
 	const blocks = getBlockTypes();
 	blocks.forEach(({ name }) {
 		if (disallowedBlocks.includes(name)) {
@@ -58,4 +58,63 @@ domReady(() => {
 		}
 	});
 });
+```
+
+## Allow List:
+Opposite to the approach of `unregisterBlockType` would be to create a PHP allow list. In this scenario a developer would curate the specific blocks that they want to have shown to an editor. In these situations it is advised to always include common utility blocks such as: `core/block`, `core/missing`, `core/pattern`, `core/template-part` to prevent issues with the block editor. 
+
+**NOTE** - When using an allow list it is advised to review WordPress releases for any changes in existing blocks. As an example WordPress 6.1 refactored the list block from one singular block to an inner blocks structure with a list item. Anyone that used an allow list at that point needed to go in and update it to include the core/list-item block.
+
+## Code Example:
+```php
+add_filter( 'allowed_block_types_all', __NAMESPACE__ . '\get_allowed_blocks', 10 );
+
+/**
+ * Returns allowed blocks.
+ */
+function get_allowed_blocks() {
+	return [
+		'core/block',
+		'core/button',
+		'core/buttons',
+		'core/column',
+		'core/columns',
+		'core/cover',
+		'core/embed',
+		'core/group',
+		'core/heading',
+		'core/image',
+		'core/list-item',
+		'core/list',
+		'core/media-text',
+		'core/paragraph',
+		'core/separator',
+		'core/shortcode',
+		'core/social-link',
+		'core/social-links',
+		'core/table',
+		'gravityforms/form',
+		'core/query',
+		'core/query-pagination',
+		'core/query-pagination-next',
+		'core/query-pagination-numbers',
+		'core/query-pagination-previous',
+		'core/post-template',
+	];
+}
+```
+
+### Automatically Add Custom Blocks to the Allow List Snippet:
+As a code base grows and more custom blocks are created this snippet is a quick way to ensure that the custom blocks that have been newly created are also added to the allow list.
+
+```php
+$block = register_block_type_from_metadata( $block_folder, $block_options );
+
+add_filter(
+	'allowed_block_types_all',
+	function ( $block_list ) use ( $block ) {
+		return array_merge( $block_list, [ $block->name ] );
+	},
+	10
+);
 ```

--- a/reference/03-Blocks/unregister-block.md
+++ b/reference/03-Blocks/unregister-block.md
@@ -1,0 +1,54 @@
+---
+sidebar_position: 10
+---
+
+# Unregister a Block
+
+## Reference Guide WordPress Documentation:
+* [unregisterBlockType](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-blocks/#unregisterblocktype)
+
+## Use Case:
+Gutenberg comes with a lot of core blocks. When creating custom builds for clients all of these core blocks are generally not needed nor should they be used by the client. In these situations it is necessary to disable the blocks from the block editor so that a user can not access them when creating new pages and posts with the block editor. This can be done using the `unregisterBlockType` function and passing in the blocks which should be disallowed within a `.js` file. 
+
+
+## Code Example:
+This example showcases how an array of blocks can be passed into a single function and looped through to disable multiple blocks at the same time. 
+
+`block-filters/unregister-blocks.js`
+```bash
+const { unregisterBlockType } = wp.blocks;
+
+const disallowedBlocks = [
+	'core/preformatted',
+	'core/table',
+	'core/code',
+	'core/video',
+	'core/verse',
+	'core/avatar',
+	'core/audio',
+	'core/calendar',
+	'core/freeform',
+];
+
+wp.domReady(() => {
+	wp.blocks.getBlockTypes().forEach(function (blockType) {
+		if (disallowedBlocks.indexOf(blockType.name) !== -1) unregisterBlockType(blockType.name);
+	});
+});
+```
+
+### Another Example - Variations:
+In this use case only `core/embed` has many variations of embeds available to a user but per client requirements only Vimeo and YouTube should be available as other platforms are not supported.
+
+`block-variations/unregister-core-embed-variation.js`
+```bash
+const allowedEmbedBlocks = ['vimeo', 'youtube'];
+
+wp.domReady(function () {
+	wp.blocks.getBlockVariations('core/embed').forEach(function (blockVariation) {
+		if (allowedEmbedBlocks.indexOf(blockVariation.name) === -1) {
+			wp.blocks.unregisterBlockVariation('core/embed', blockVariation.name);
+		}
+	});
+});
+```

--- a/reference/03-Blocks/unregister-block.md
+++ b/reference/03-Blocks/unregister-block.md
@@ -41,7 +41,7 @@ wp.domReady(() => {
 ```
 
 ### Another Example - Variations:
-In this use case only `core/embed` has many variations of embeds available to a user but per client requirements only Vimeo and YouTube should be available as other platforms are not supported. In this use case `unregisterBlockVariation` is used since it is related to a `variation` of a block.
+Something that also comes up all the time is the need to remove individual block variations. The core embed block for example uses block variations to expose the various embed providers as separate items in the block inserted. If a client however has strict requirements to only ever embed videos using YouTube for example, we want to hide all the other embed providers. We can achieve that using the `unregisterBlockVariation` function.
 
 `block-variations/unregister-core-embed-variation.js`
 ```bash

--- a/reference/03-Blocks/unregister-block.md
+++ b/reference/03-Blocks/unregister-block.md
@@ -31,8 +31,11 @@ const disallowedBlocks = [
 ];
 
 wp.domReady(() => {
-	wp.blocks.getBlockTypes().forEach(function (blockType) {
-		if (disallowedBlocks.indexOf(blockType.name) !== -1) unregisterBlockType(blockType.name);
+	const blocks = getBlockTypes();
+	blocks.forEach(({ name }) {
+		if (disallowedBlocks.includes(name)) {
+			unregisterBlockType(name);
+		}
 	});
 });
 ```

--- a/reference/03-Blocks/unregister-block.md
+++ b/reference/03-Blocks/unregister-block.md
@@ -16,7 +16,7 @@ This example showcases how an array of blocks can be passed into a single functi
 
 `block-filters/unregister-blocks.js`
 ```js
-const { unregisterBlockType } = wp.blocks;
+import { unregisterBlockType } from '@wordpress/blocks';
 
 const disallowedBlocks = [
 	'core/preformatted',

--- a/reference/03-Blocks/unregister-block.md
+++ b/reference/03-Blocks/unregister-block.md
@@ -38,7 +38,7 @@ wp.domReady(() => {
 ```
 
 ### Another Example - Variations:
-In this use case only `core/embed` has many variations of embeds available to a user but per client requirements only Vimeo and YouTube should be available as other platforms are not supported.
+In this use case only `core/embed` has many variations of embeds available to a user but per client requirements only Vimeo and YouTube should be available as other platforms are not supported. In this use case `unregisterBlockVariation` is used since it is related to a `variation` of a block.
 
 `block-variations/unregister-core-embed-variation.js`
 ```bash

--- a/reference/03-Blocks/unregister-block.md
+++ b/reference/03-Blocks/unregister-block.md
@@ -15,7 +15,7 @@ Gutenberg comes with a lot of core blocks. When creating custom builds for clien
 This example showcases how an array of blocks can be passed into a single function and looped through to disable multiple blocks at the same time. 
 
 `block-filters/unregister-blocks.js`
-```bash
+```js
 const { unregisterBlockType } = wp.blocks;
 
 const disallowedBlocks = [

--- a/reference/03-Blocks/unregister-block.md
+++ b/reference/03-Blocks/unregister-block.md
@@ -44,7 +44,7 @@ wp.domReady(() => {
 Something that also comes up all the time is the need to remove individual block variations. The core embed block for example uses block variations to expose the various embed providers as separate items in the block inserted. If a client however has strict requirements to only ever embed videos using YouTube for example, we want to hide all the other embed providers. We can achieve that using the `unregisterBlockVariation` function.
 
 `block-variations/unregister-core-embed-variation.js`
-```bash
+```js
 const allowedEmbedBlocks = ['vimeo', 'youtube'];
 
 wp.domReady(function () {

--- a/reference/03-Blocks/unregister-block.md
+++ b/reference/03-Blocks/unregister-block.md
@@ -45,12 +45,16 @@ Something that also comes up all the time is the need to remove individual block
 
 `block-variations/unregister-core-embed-variation.js`
 ```js
+import domReady from '@wordpress/dom-ready';
+import { getBlockVariations, unregisterBlockVariation } from '@wordpress/blocks';
+
 const allowedEmbedBlocks = ['vimeo', 'youtube'];
 
-wp.domReady(function () {
-	wp.blocks.getBlockVariations('core/embed').forEach(function (blockVariation) {
-		if (allowedEmbedBlocks.indexOf(blockVariation.name) === -1) {
-			wp.blocks.unregisterBlockVariation('core/embed', blockVariation.name);
+domReady(() => {
+	const embedVariations = getBlockVariations('core/embed');
+	embedVariations.forEach(({name}) => {
+		if (allowedEmbedBlocks.includes(name)) {
+			unregisterBlockVariation('core/embed', name);
 		}
 	});
 });


### PR DESCRIPTION
<!-- Thanks for contributing to the 10up Gutenberg Best Practices! -->

## Description of the Change
<!-- In a few words, what is the PR actually doing? -->
This reference showcases how to disallow multiple blocks and variations from Gutenberg using the unregisterBlockType 
 and unregisterBlockVariation functions. This PR also fixes some issues pertaining to the documentation side navigation order.

Closing # https://github.com/10up/gutenberg-best-practices/issues/26
