### PR TITLE
Improve text underline position

### DIFF
--- a/src/css/global-site.css
+++ b/src/css/global-site.css
@@ -44,6 +44,7 @@ section + hr {
 
 a {
   font-weight: var(--ifm-font-weight-semibold);
+  text-underline-position: under;
 }
 
 /* Stops iOS from zooming the code too much (bug) */


### PR DESCRIPTION
<!-- Thanks for contributing to the 10up Gutenberg Best Practices! -->

## Description of the Change
Small change to the text underline position that improves legibility of links around `<code>` tags.

This also slightly affects regular links. See examples.

### Before with links around code
![screen-capture 2023-12-09 at 3 59 30 PM](https://github.com/10up/gutenberg-best-practices/assets/12365909/33a619f3-a33b-4b5a-a016-f01b4ee6b705)

![screen-capture 2023-12-09 at 2 42 23 PM](https://github.com/10up/gutenberg-best-practices/assets/12365909/4cfea7cf-ba1f-42eb-9069-bca843c6e622)

### After with links around code
![screen-capture 2023-12-09 at 4 00 00 PM](https://github.com/10up/gutenberg-best-practices/assets/12365909/c5053155-02e6-4855-8d2d-181d1197568b)

![screen-capture 2023-12-09 at 2 42 01 PM](https://github.com/10up/gutenberg-best-practices/assets/12365909/840401ee-7d60-494b-ba9b-2ee3e6fa8ef6)

### Before with regular links
![Capture-2023-12-09-144439](https://github.com/10up/gutenberg-best-practices/assets/12365909/460c65c6-da30-4890-b855-6f6c57a931e1)

### After with regular links
![Capture-2023-12-09-144419](https://github.com/10up/gutenberg-best-practices/assets/12365909/df03d52c-406f-4981-8208-d11dadf4f641)

Closing (N/A)
