### PR TITLE
Adjust main container margins and max-width

### DIFF
--- a/src/css/docs-content.css
+++ b/src/css/docs-content.css
@@ -8,6 +8,3 @@
 	background-color: #fff; /* Keep white so pngs get bg in dark mode. */
 }
 
-main > .container {
-	margin-bottom: 4rem;
-}

--- a/src/css/global-site.css
+++ b/src/css/global-site.css
@@ -24,7 +24,13 @@ html[data-theme="dark"] .theme-announcement-bar {
 }
 
 main > .container {
-  margin-top: 4rem;
+  max-width: none;
+}
+
+@media (min-width: 1440px) {
+  main > .container {
+    max-width: var(--ifm-container-width-xl);
+  }
 }
 
 .theme-doc-markdown iframe {


### PR DESCRIPTION
## Summary
- Removed the 4rem top/bottom margins on `main > .container` — too much spacing on most viewports
- Removed the default `max-width` cap — content area was too narrow on certain widths
- Added a responsive cap at 1440px using `--ifm-container-width-xl` so it doesn't run wild on large screens

## Test plan
- [ ] Check doc pages at various viewport widths
- [ ] Confirm content fills available width below 1440px
- [ ] Confirm content caps at `--ifm-container-width-xl` above 1440px
- [ ] Verify footer and sidebar are unaffected