### PR TITLE
Fix search input clear button and hint container positioning

### DIFF
--- a/src/css/homepage-search.css
+++ b/src/css/homepage-search.css
@@ -40,13 +40,6 @@
 }
 
 [class^="searchBarContainer_"] [class^="searchClearButton_"] {
-  background: none !important;
-  border: none !important;
-  line-height: 1rem !important;
-  padding: 0 !important;
-  position: absolute !important;
-  top: 50% !important;
-  transform: translateY(-50%) !important;
   right: 7px !important;
   text-align: right !important;
 }

--- a/src/css/homepage-search.css
+++ b/src/css/homepage-search.css
@@ -39,16 +39,16 @@
   color: var(--ifm-color-content);
 }
 
-.navbar .navbar__search [class^="searchBarContainer_"] [class^="searchClearButton_"] {
-  background: none;
-  border: none;
-  line-height: 1rem;
-  padding: 0;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  right: 7px;
-  text-align: right;
+[class^="searchBarContainer_"] [class^="searchClearButton_"] {
+  background: none !important;
+  border: none !important;
+  line-height: 1rem !important;
+  padding: 0 !important;
+  position: absolute !important;
+  top: 50% !important;
+  transform: translateY(-50%) !important;
+  right: 7px !important;
+  text-align: right !important;
 }
 
 .navbar__search [class^="searchHintContainer_"] {

--- a/src/css/homepage-search.css
+++ b/src/css/homepage-search.css
@@ -24,11 +24,6 @@
   color: var(--ifm-color-content);
 }
 
-.home__heroBanner
-  [class="searchHintContainer_node_modules-@easyops-cn-docusaurus-search-local-dist-client-client-theme-SearchBar-SearchBar-module"] {
-  display: none !important;
-}
-
 .home__heroBanner .navbar__search input {
   background-color: var(--ifm-input-background-color);
   border-radius: 0.75em;
@@ -42,4 +37,28 @@
   margin-left: auto;
   font-size: 1.125rem;
   color: var(--ifm-color-content);
+}
+
+[class^="searchBarContainer_"] [class^="searchClearButton_"] {
+  background: none;
+  border: none;
+  line-height: 1rem;
+  padding: 0;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  right: 7px;
+  text-align: right;
+}
+
+[class^="searchHintContainer_"] {
+  align-items: center;
+  display: flex;
+  gap: 4px;
+  height: 100%;
+  justify-content: end;
+  pointer-events: none;
+  position: absolute;
+  right: 10px;
+  top: 0;
 }

--- a/src/css/homepage-search.css
+++ b/src/css/homepage-search.css
@@ -44,7 +44,7 @@
   color: var(--ifm-color-content);
 }
 
-[class^="searchBarContainer_"] [class^="searchClearButton_"] {
+[class*="searchBarContainer_"] [class*="searchClearButton_"] {
   right: 7px !important;
   text-align: right !important;
 }

--- a/src/css/homepage-search.css
+++ b/src/css/homepage-search.css
@@ -39,7 +39,7 @@
   color: var(--ifm-color-content);
 }
 
-.navbar__search [class^="searchBarContainer_"] [class^="searchClearButton_"] {
+.navbar .navbar__search [class^="searchBarContainer_"] [class^="searchClearButton_"] {
   background: none;
   border: none;
   line-height: 1rem;

--- a/src/css/homepage-search.css
+++ b/src/css/homepage-search.css
@@ -39,7 +39,7 @@
   color: var(--ifm-color-content);
 }
 
-[class^="searchBarContainer_"] [class^="searchClearButton_"] {
+.navbar__search [class^="searchBarContainer_"] [class^="searchClearButton_"] {
   background: none;
   border: none;
   line-height: 1rem;
@@ -51,7 +51,7 @@
   text-align: right;
 }
 
-[class^="searchHintContainer_"] {
+.navbar__search [class^="searchHintContainer_"] {
   align-items: center;
   display: flex;
   gap: 4px;

--- a/src/css/homepage-search.css
+++ b/src/css/homepage-search.css
@@ -52,13 +52,5 @@
 }
 
 .navbar__search [class^="searchHintContainer_"] {
-  align-items: center;
-  display: flex;
-  gap: 4px;
-  height: 100%;
   justify-content: end;
-  pointer-events: none;
-  position: absolute;
-  right: 10px;
-  top: 0;
 }

--- a/src/css/homepage-search.css
+++ b/src/css/homepage-search.css
@@ -24,6 +24,11 @@
   color: var(--ifm-color-content);
 }
 
+.home__heroBanner
+  [class="searchHintContainer_node_modules-@easyops-cn-docusaurus-search-local-dist-client-client-theme-SearchBar-SearchBar-module"] {
+  display: none !important;
+}
+
 .home__heroBanner .navbar__search input {
   background-color: var(--ifm-input-background-color);
   border-radius: 0.75em;


### PR DESCRIPTION
## Summary
- Override third-party `@easyops-cn/docusaurus-search-local` styles to properly position the clear button (absolute, right-aligned at 7px) and keyboard shortcut hint container (absolute, right-aligned at 10px) inside the navbar search input
- Remove fragile exact-match `searchHintContainer` selector in favor of existing robust `[class^="searchHintContainer_"]` prefix selector in `homepage-components.css`

## Test plan
- [ ] Verify the search clear button appears inside the input, right-aligned
- [ ] Verify the keyboard shortcut hint is right-aligned inside the input
- [ ] Verify the hero banner search still hides the hint container