### PR TITLE
Update References for WordPress 7.0

### DIFF
--- a/guides/api-version-2.md
+++ b/guides/api-version-2.md
@@ -1,6 +1,10 @@
-# A Quick Guide for Gutenberg API Version 2
+# A Quick Guide for Gutenberg API Version 2 & 3
 
 First of all there is no need to freak out. I know API Version 2 sounds scary like everything is changing but that is not the case. In fact if you don't want to nothing has to change. API Version 2 is opt in and therefore does not impact anything if you don't want it to. But there are good reasons why you may want to use it.
+
+:::info WordPress 7.0
+For new blocks, prefer **API Version 3**. Starting in WordPress 7.0 the iframed editor is enforced when every block on the post is v3+, which gives editors a much more accurate preview of the frontend. The two changes described on this page (`useBlockProps` + dropping the wrapper `<div>`) are also required for v3, so this guide is still the right starting point.
+:::
 
 ## Benefits
 

--- a/guides/interactivity-api-getting-started.md
+++ b/guides/interactivity-api-getting-started.md
@@ -207,6 +207,45 @@ $additional_attributes = [
 </div>
 ```
 
+## Reacting to state changes (WordPress 7.0)
+
+WordPress 7.0 adds two new tools for running side-effects when state or context changes:
+
+### `watch()`
+
+Imported from `@wordpress/interactivity`, `watch()` subscribes a callback to any signals it reads. It runs once immediately and again any time those signals change, and the optional return value is treated as a cleanup function (similar to `useEffect`).
+
+```js
+import { store, getContext, watch } from '@wordpress/interactivity';
+
+store('namespace/block-name', {
+    callbacks: {
+        logActiveState() {
+            // Re-runs every time isActive changes.
+            watch(() => {
+                const { isActive } = getContext();
+                console.log('isActive →', isActive);
+            });
+        },
+    },
+});
+```
+
+### `data-wp-watch`
+
+The directive counterpart of `watch()`. Attach `data-wp-watch="callbacks.someCallback"` to a DOM element and the referenced callback re-runs every time its tracked signals change, with full access to the element's lifecycle (mount/unmount). This replaces most manual `data-wp-init` + custom subscription patterns.
+
+```html
+<div
+    data-wp-interactive="namespace/block-name"
+    data-wp-watch="callbacks.logActiveState"
+>
+    …
+</div>
+```
+
+`state.url` is also now populated server-side, so SSR pages can read the current URL without waiting for the first client-side navigation.
+
 ## Conclusion
 
 The Interactivity API is a powerful new way to write frontend JavaScript for blocks. It is designed to be declarative and easy to use. This guide has shown you the basics of how to get started with the Interactivity API and how to write your first interactive block.

--- a/reference/02-Themes/fonts.md
+++ b/reference/02-Themes/fonts.md
@@ -81,9 +81,13 @@ Most of the time you won't actually want to manually write all the JSON to add y
 
 ## Font Library
 
-The font library is part of the Global Styles section inside the site editor of a block theme. It visually allows administrators to manage which fonts are installed on their site.
+The Font Library lets administrators visually manage which fonts are installed on their site.
 
-The font library exposes available font collections in the UI. By default WordPress core includes a collection for Google Fonts. But any developer can add additional font collections in the same way using the `wp_register_font_collection` function.
+:::tip WordPress 7.0
+WordPress 7.0 promotes the Font Library to a **dedicated page under `Appearance → Fonts`** and makes it available to **all themes**, including classic and hybrid themes — not just block themes. Previously it only lived inside the Site Editor's Global Styles panel.
+:::
+
+The Font Library exposes available font collections in the UI. By default WordPress core includes a collection for Google Fonts. But any developer can add additional font collections in the same way using the `wp_register_font_collection` function.
 
 You can [learn more about registering custom font collections in the core documentation](https://make.wordpress.org/core/2024/03/14/new-feature-font-library/#adding-a-font-collection).
 

--- a/reference/02-Themes/navigation.md
+++ b/reference/02-Themes/navigation.md
@@ -38,3 +38,19 @@ Something we have also done, is creating a custom navigation block that uses the
 ### 4. Custom Navigation Block that uses the old menu system
 
 Another option is to create a custom navigation block that uses the old menu system. This way you can still use the old menu editor to assign a menu to a navigation area. This approach does retain the familiarity of the old system, but it also means you are not using the new block-based system to its full potential.
+
+## Navigation Overlays (WordPress 7.0)
+
+WordPress 7.0 introduces fully customizable **navigation overlays** for the mobile hamburger menu. The overlay is now driven by a regular block pattern that you can edit directly in the Site Editor, and the new `core/navigation-overlay-close` block exposes a styleable close affordance.
+
+Highlights:
+
+- Overlays are editable in-place and previewable from the Navigation block toolbar.
+- Themes can ship a **default overlay template** that the editor uses as the starting point whenever the overlay is opened for the first time.
+- The four overlay patterns bundled with core (centered, accent, dark, plain) can be unregistered or replaced with theme-specific ones.
+
+When building a custom 10up theme:
+
+1. Register an overlay pattern with the `header` category and the `core/navigation-overlay` template area so it's available in the overlay picker.
+2. Include `core/navigation-overlay-close` inside the pattern and style it via `theme.json` to match the rest of the design system.
+3. For client builds where editors should not switch overlays, lock the Navigation block's overlay attribute through the `block_editor_settings_all` filter.

--- a/reference/02-Themes/theme-json.md
+++ b/reference/02-Themes/theme-json.md
@@ -161,6 +161,301 @@ Using `useSettings(['typography.dropCap'])` would only return `[true]` if it is 
 </p>
 </details>
 
+## Schema version
+
+The `version` key at the root of `theme.json` controls which schema is in use:
+
+| Version | Introduced | Notes |
+| ------- | ---------- | ----- |
+| 1 | 5.8 | Initial release, deprecated. |
+| 2 | 5.9 | Default for several years. Most settings/styles documented here are v2. |
+| 3 | 6.6 | Adopts the modern fluid typography defaults, sectioned styles, and the `dimensions.defaultAspectRatios` toggle. |
+
+```json title="theme.json"
+{
+    "$schema": "https://schemas.wp.org/trunk/theme.json",
+    "version": 3
+}
+```
+
+When migrating from v2 → v3, WordPress automatically rewrites theme tokens at runtime, but you should still review fluid typography output and aspect ratio presets because the defaults change.
+
+## Settings reference
+
+Below are the settings most commonly used on 10up builds, grouped by area. All of them live under the top-level `settings` key (and can be repeated inside `settings.blocks[blockName]` for per-block overrides).
+
+### Appearance tools shortcut
+
+```json
+"settings": {
+    "appearanceTools": true
+}
+```
+
+Setting `appearanceTools: true` enables the full set of design controls in one go (border, color link, color heading, color button, spacing, typography line-height, etc.). This is the recommended starting point for most 10up themes — turn it on globally and then disable specific controls per block as needed.
+
+### Layout & root padding
+
+```json
+"settings": {
+    "layout": {
+        "contentSize": "640px",
+        "wideSize":    "1200px"
+    },
+    "useRootPaddingAwareAlignments": true
+}
+```
+
+`useRootPaddingAwareAlignments` (added in 6.1) moves the root padding to inner blocks so that `align: full` blocks can still extend edge-to-edge while content blocks honor the gutter. This is now the default for new block themes.
+
+### Spacing presets (added in 5.9, expanded in 6.1)
+
+```json
+"settings": {
+    "spacing": {
+        "units":          [ "px", "em", "rem", "%", "vw", "vh" ],
+        "padding":        true,
+        "margin":         true,
+        "blockGap":       true,
+        "spacingScale":   { "operator": "*", "increment": 1.5, "steps": 7, "mediumStep": 1.5, "unit": "rem" },
+        "spacingSizes":   [
+            { "slug": "20", "size": "0.5rem", "name": "Small" },
+            { "slug": "30", "size": "1rem",   "name": "Medium" },
+            { "slug": "40", "size": "2rem",   "name": "Large" }
+        ]
+    }
+}
+```
+
+`spacingScale` auto-generates a `t-shirt` style scale; `spacingSizes` lets you author named presets manually. If both are provided, `spacingSizes` wins. Presets are exposed both in the spacing controls and as `var(--wp--preset--spacing--{slug})` CSS variables.
+
+### Typography (added throughout 5.9 → 7.0)
+
+```json
+"settings": {
+    "typography": {
+        "fontSizes":       [ /* ... */ ],
+        "fontFamilies":    [ /* ... */ ],
+        "fluid":           true,
+        "customFontSize":  true,
+        "fontStyle":       true,
+        "fontWeight":      true,
+        "letterSpacing":   true,
+        "lineHeight":      true,
+        "textAlign":       true,
+        "textColumns":     true,
+        "textDecoration":  true,
+        "textIndent":      true,
+        "textTransform":   true,
+        "writingMode":     true,
+        "dropCap":         false
+    }
+}
+```
+
+Highlights:
+
+- `typography.fluid` (added in 6.1) enables CSS `clamp()`-based fluid sizing. In v3 it can also be defined per-font-size via `fluid: { min, max }` on individual entries.
+- `typography.textAlign` (6.6) and `typography.textIndent` (7.0) are the most recent additions.
+- Set `customFontSize: false` to lock editors to your preset scale.
+
+### Border settings (added in 5.9)
+
+```json
+"settings": {
+    "border": {
+        "color":  true,
+        "radius": true,
+        "style":  true,
+        "width":  true
+    }
+}
+```
+
+### Color (with duotone added in 5.9)
+
+```json
+"settings": {
+    "color": {
+        "palette":           [ /* preset colors */ ],
+        "gradients":         [ /* preset gradients */ ],
+        "duotone":           [ /* preset duotone filters */ ],
+        "background":        true,
+        "text":              true,
+        "link":              true,
+        "heading":           true,
+        "button":            true,
+        "caption":           true,
+        "customDuotone":     true,
+        "defaultPalette":    false,
+        "defaultGradients":  false,
+        "defaultDuotone":    false
+    }
+}
+```
+
+Disable the `default*` keys when you want only your brand presets to show up — by default WordPress merges in its own palette and duotone filters.
+
+### Shadow presets (added in 6.3)
+
+```json
+"settings": {
+    "shadow": {
+        "defaultPresets": false,
+        "presets": [
+            { "slug": "soft",   "shadow": "0 4px 12px rgba(0,0,0,0.08)", "name": "Soft" },
+            { "slug": "strong", "shadow": "0 12px 32px rgba(0,0,0,0.18)", "name": "Strong" }
+        ]
+    }
+}
+```
+
+These presets feed both the global shadow picker in the site editor and any block that opts into the `shadow` block support.
+
+### Dimensions (added in 6.5, expanded in 7.0)
+
+```json
+"settings": {
+    "dimensions": {
+        "defaultAspectRatios": true,
+        "aspectRatios": [
+            { "slug": "wide", "ratio": "16/9", "name": "Wide" }
+        ],
+        "minHeight": [
+            { "slug": "small", "size": "20rem", "name": "Small" },
+            { "slug": "large", "size": "60rem", "name": "Large" }
+        ]
+    }
+}
+```
+
+WordPress 7.0 also adds `height` and `width` preset arrays for the new `dimensions.height` / `dimensions.width` block supports.
+
+### Background (added in 6.4)
+
+```json
+"settings": {
+    "background": {
+        "backgroundImage": true,
+        "backgroundSize":  true
+    }
+}
+```
+
+When enabled, blocks that opt into the `background` block support can accept background images directly from the inspector.
+
+### Lightbox (added in 6.4)
+
+```json
+"settings": {
+    "blocks": {
+        "core/image": {
+            "lightbox": { "enabled": true, "allowEditing": true }
+        }
+    }
+}
+```
+
+Turns the click-to-zoom lightbox on for the Image block site-wide. The Gallery block also supports it via the same setting.
+
+### Custom CSS toggle (added in 6.2)
+
+```json
+"settings": {
+    "css": true
+}
+```
+
+Required for the `styles.css` and `styles.blocks[blockName].css` keys to be honored.
+
+## Styles reference
+
+`styles` mirrors `settings` in that you can target the whole site (`styles.*`), individual elements (`styles.elements.*`), and individual blocks (`styles.blocks[blockName].*`).
+
+### Element styles (added in 5.9, expanded in 6.x)
+
+```json
+"styles": {
+    "elements": {
+        "link":    { "color": { "text": "var(--wp--preset--color--accent)" } },
+        "button":  { /* … */ },
+        "heading": { "typography": { "fontFamily": "var(--wp--preset--font-family--display)" } },
+        "h1":      { "typography": { "fontSize": "var(--wp--preset--font-size--xx-large)" } },
+        "h2":      { /* … */ },
+        "caption": { "typography": { "fontSize": "0.875rem" } },
+        "cite":    { /* … */ }
+    }
+}
+```
+
+Element styles cascade across **every** block that renders that HTML element, which is exactly what you want for a design-system theme.
+
+### Per-block & per-element interaction states
+
+```json
+"styles": {
+    "elements": {
+        "link": {
+            "color":  { "text": "var(--wp--preset--color--accent)" },
+            ":hover": { "color": { "text": "var(--wp--preset--color--accent-2)" } },
+            ":focus": { /* … */ }
+        }
+    }
+}
+```
+
+`:hover`, `:focus`, `:focus-visible`, and `:active` are supported on link and button elements. WordPress 7.0 extends this to the `core/button` block specifically (see below).
+
+### Custom CSS per block / globally (added in 6.2)
+
+```json
+"styles": {
+    "css": ":root { --site-max-width: 1280px; }",
+    "blocks": {
+        "core/quote": {
+            "css": "& { border-inline-start: 4px solid currentColor; padding-inline-start: var(--wp--preset--spacing--40); }"
+        }
+    }
+}
+```
+
+The `&` selector is automatically replaced with the block's root selector, so you can scope styles without duplicating the class name.
+
+### Style variations (added in 6.6)
+
+```json
+"styles": {
+    "blocks": {
+        "core/group": {
+            "variations": {
+                "accent": {
+                    "color": { "background": "var(--wp--preset--color--accent)" }
+                }
+            }
+        }
+    }
+}
+```
+
+Any variation defined this way is automatically registered as a block style on `core/group` and surfaces in the Styles panel.
+
+### Pseudo-element styles on `core/button` (added in 7.0)
+
+```json title="theme.json"
+{
+    "version": 3,
+    "styles": {
+        "blocks": {
+            "core/button": {
+                "color": { "background": "var(--wp--preset--color--accent)" },
+                ":hover":         { "color": { "background": "var(--wp--preset--color--accent-2)" } },
+                ":focus-visible": { "outline": { "width": "2px", "style": "solid", "color": "currentColor", "offset": "2px" } }
+            }
+        }
+    }
+}
+```
+
 ## Filtering `theme.json` data
 
 Starting in WordPress 6.1 it is possible to filter the values of `theme.json` on the server. There are 4 different hooks for the 4 different layers or `theme.json`. Default, Blocks, Theme, and User.
@@ -243,3 +538,4 @@ addFilter(
 - [Filters for theme.json data - WordPress 6.1 Dev Note](https://make.wordpress.org/core/2022/10/10/filters-for-theme-json-data/)
 - [How to modify theme.json data using server-side filters - WordPress Developer Blog](https://developer.wordpress.org/news/2023/07/how-to-modify-theme-json-data-using-server-side-filters/)
 - [Customize settings for any block in WordPress 6.2 - WordPress 6.2 Dev Note](https://make.wordpress.org/core/2023/02/28/custom-settings-wordpress-6-2/)
+- [WordPress 7.0 Field Guide](https://make.wordpress.org/core/2026/05/14/wordpress-7-0-field-guide/)

--- a/reference/03-Blocks/block-supports.md
+++ b/reference/03-Blocks/block-supports.md
@@ -16,8 +16,9 @@ Opting into any of these features will register additional attributes on the blo
 - Default value: `false`
 
 Anchors let you link directly to a specific block on a page. This property adds a field to define an id for the block and a button to copy the direct link.
-:::warning
-This doesn't work with dynamic blocks yet. If you need to add Anchor support to a block that uses PHP rendering you need to manually add the attribute and UI for it.
+
+:::tip WordPress 7.0
+As of WordPress 7.0, `anchor` support is fully wired up for **dynamic blocks** as well. The anchor value is now stored on the block comment delimiter and automatically applied to the wrapper attributes returned by `get_block_wrapper_attributes()` — no manual attribute or UI registration required for PHP-rendered blocks.
 :::
 
 ```json
@@ -95,6 +96,49 @@ This property allows to enable [wide alignment](https://developer.wordpress.org/
  }
  ```
 
+## background
+
+_Added in WordPress 6.4._
+
+- Type: `Object`
+- Default value: null
+- Subproperties:
+  - `backgroundImage`: type `boolean`, default value `false`
+  - `backgroundSize`: type `boolean`, default value `false` _(added in 6.5)_
+
+When enabled, the editor surfaces a background image control in the block's inspector. Setting `backgroundSize` to `true` adds a "Size" control (`cover`, `contain`, custom) alongside it.
+
+```json
+"supports": {
+    "background": {
+        "backgroundImage": true,
+        "backgroundSize":  true
+    }
+}
+```
+
+The selected values are written to the `style.background.backgroundImage` and `style.background.backgroundSize` attributes and end up as inline CSS on the block wrapper via `get_block_wrapper_attributes()`.
+
+## blockHooks
+
+_Added in WordPress 6.4._
+
+- Type: `Object`
+- Default value: null
+
+Block Hooks let a block declare that it should be **auto-inserted** relative to another block (typically a template part or a specific core block). The keys are the names of the blocks you want to attach to and the values are the insertion position.
+
+Supported positions: `before`, `after`, `firstChild`, `lastChild`.
+
+```json
+"blockHooks": {
+    "core/post-content":   "after",
+    "core/template-part/footer": "lastChild"
+}
+```
+
+This is the recommended way to inject blocks like "Back to top", "Reading progress", or a "Cookie banner" without editing every template by hand. Editors can still remove or move the auto-inserted block from the list view.
+
 ## className
 
 - Type: `boolean`
@@ -121,11 +165,22 @@ In general it is recommended for consistency sake to stick with the core generat
 - Default value: null
 - Subproperties:
   - `background`: type `boolean`, default value `true`
+  - `button`: type `boolean`, default value `false` _(added in 6.5)_
+  - `caption`: type `boolean`, default value `false` _(added in 6.3)_
+  - `enableContrastChecker`: type `boolean`, default value `true` _(added in 6.5)_
   - `gradients`: type `boolean`, default value `false`
+  - `heading`: type `boolean`, default value `false` _(added in 6.4)_
   - `link`: type `boolean`, default value `false`
   - `text`: type `boolean`, default value `true`
 
 This value signals that a block supports some of the properties related to color. When it does, the block editor will show UI controls for the user to set their values.
+
+In addition to the `text`/`background`/`gradients`/`link` controls described below, you can also expose color pickers that target semantic descendants of the block:
+
+- `color.heading` — styles any `h1`–`h6` inside the block (great for hero/group blocks).
+- `color.button` — styles any `core/button` inside the block.
+- `color.caption` — styles caption text on media blocks.
+- `color.enableContrastChecker` — toggle the accessibility contrast checker that shows next to color pickers (default `true`).
 
 Note that the `background` and `text` keys have a default value of `true`, so if the `color` property is present they'll also be considered enabled:
 
@@ -383,6 +438,33 @@ When the block declares support for `color.text`, the attributes definition is e
   }
   ```
 
+## dimensions
+
+- Type: `Object`
+- Default value: null
+- Subproperties:
+  - `aspectRatio`: type `boolean`, default value `false`
+  - `minHeight`: type `boolean`, default value `false`
+  - `height`: type `boolean`, default value `false` _(added in WordPress 7.0)_
+  - `width`: type `boolean`, default value `false` _(added in WordPress 7.0)_
+
+This value signals that a block supports CSS dimensions. When it does, the block editor will show UI controls for the user to set their values, if the theme declares matching presets in `settings.dimensions` of `theme.json`.
+
+```json
+"supports": {
+    "dimensions": {
+        "aspectRatio": true,
+        "minHeight":   true,
+        "height":      true,
+        "width":       true
+    }
+}
+```
+
+:::tip WordPress 7.0
+WordPress 7.0 introduces `dimensions.height` and `dimensions.width` block supports along with reusable size presets in `theme.json`'s `settings.dimensions` array. The Cover and Image blocks now also support aspect ratio for `wide` and `full` alignments.
+:::
+
 ## customClassName
 
 ![Block Editor Sidebar showing the custom class name setting](../../static//img/supports-classname.png)
@@ -412,6 +494,35 @@ When the style picker is shown, the user can set a default style for a block typ
 "supports": {
     // Remove the Default Style picker.
     "defaultStylePicker": false
+}
+```
+
+## filter
+
+_Added in WordPress 5.9 (duotone). Promoted to the top-level `filter` support in 6.3._
+
+- Type: `Object`
+- Default value: null
+- Subproperties:
+  - `duotone`: type `boolean`, default value `false`
+
+Enables a duotone color filter control. Themes can pre-define duotone presets via `settings.color.duotone` in `theme.json`.
+
+```json
+"supports": {
+    "filter": {
+        "duotone": true
+    }
+}
+```
+
+To apply the generated filter on the frontend you also need to declare a CSS selector via `selectors.filter.duotone` in `block.json`:
+
+```json
+"selectors": {
+    "filter": {
+        "duotone": ".wp-block-namespace-block img"
+    }
 }
 ```
 
@@ -445,6 +556,65 @@ By default, all blocks will appear in the inserter. To hide a block so that it c
 }
 ```
 
+## interactivity
+
+_Added in WordPress 6.5._
+
+- Type: `boolean` or `Object`
+- Default value: `false`
+- Subproperties:
+  - `clientNavigation`: type `boolean`, default value `false`
+  - `interactive`: type `boolean`, default value `false`
+
+Declares that the block uses the [Interactivity API](../../guides/interactivity-api-getting-started.md). Setting it to `true` is shorthand for `{ "interactive": true }`. Setting `clientNavigation` opts the block into the upcoming client-side navigation transitions and tells WordPress that the block's markup is safe to swap during a navigation.
+
+```json
+"supports": {
+    "interactivity": {
+        "interactive":       true,
+        "clientNavigation":  true
+    }
+}
+```
+
+## layout
+
+_Added in WordPress 5.8, expanded in 6.3._
+
+- Type: `boolean` or `Object`
+- Default value: `false`
+
+Layout support lets a block participate in the Flow / Flex / Grid layout system that powers `core/group`, `core/columns`, and similar containers. When enabled, the editor shows the layout panel in the inspector and applies the matching layout styles to inner blocks.
+
+```json
+"supports": {
+    "layout": {
+        "default": { "type": "constrained" },
+        "allowSwitching":     false,
+        "allowInheriting":    true,
+        "allowEditing":       true,
+        "allowSizingOnChildren": true
+    }
+}
+```
+
+Available layout types include `default` (flow), `constrained`, `flex`, and `grid`. The constrained layout is the recommended replacement for the legacy `contentSize` / `wideSize` `align` behavior.
+
+## listView
+
+- Type: `boolean`
+- Default value: `false`
+
+_Added in WordPress 7.0._
+
+Declaring `"listView": true` tells the editor that this block — and its inner blocks — should be discoverable in the **List View** for `contentOnly` patterns. This is the recommended way for custom blocks to surface their nested structure to editors who are working inside Pattern editing mode without exposing the full block design controls.
+
+```json
+"supports": {
+    "listView": true
+}
+```
+
 ## multiple
 
 - Type: `boolean`
@@ -456,6 +626,40 @@ A non-multiple block can be inserted into each post, one time only. For example,
 "supports": {
     // Use the block just once per post
     "multiple": false
+}
+```
+
+## position
+
+_Added in WordPress 6.2._
+
+- Type: `Object`
+- Default value: null
+- Subproperties:
+  - `sticky`: type `boolean`, default value `false`
+
+Exposes a "Position" control in the inspector with a Sticky option. Only the **outermost** block of a template/template-part can become sticky — usually this is the header.
+
+```json
+"supports": {
+    "position": {
+        "sticky": true
+    }
+}
+```
+
+## renaming
+
+_Added in WordPress 6.5._
+
+- Type: `boolean`
+- Default value: `true`
+
+By default editors can rename a block instance via the List View / block options menu. Set to `false` to disable renaming for a specific block.
+
+```json
+"supports": {
+    "renaming": false
 }
 ```
 
@@ -486,6 +690,36 @@ A block may want to disable the ability to toggle the lock state. It can be lock
 supports: {
 	// Remove support for locking UI.
 	lock: false
+}
+```
+
+## shadow
+
+_Added in WordPress 6.3._
+
+- Type: `boolean`
+- Default value: `false`
+
+Adds a box-shadow control in the inspector. The selectable shadow presets come from `settings.shadow.presets` in `theme.json`.
+
+```json
+"supports": {
+    "shadow": true
+}
+```
+
+## splitting
+
+_Added in WordPress 6.5._
+
+- Type: `boolean`
+- Default value: `false`
+
+Allows the block to be split into multiple blocks when the user presses Enter inside it (the way `core/paragraph` and `core/list-item` already behave). The block must implement the `splitting` filter / handler in its edit component.
+
+```json
+"supports": {
+    "splitting": true
 }
 ```
 
@@ -536,20 +770,42 @@ A spacing property may define an array of allowable sides that can be configured
 - Default value: `null`
 - Subproperties:
   - `fontSize`: type `boolean`, default value `false`
+  - `fontFamily`: type `boolean`, default value `false` _(added in 5.9)_
+  - `fontStyle`: type `boolean`, default value `false` _(added in 6.1)_
+  - `fontWeight`: type `boolean`, default value `false` _(added in 6.1)_
+  - `letterSpacing`: type `boolean`, default value `false` _(added in 6.1)_
   - `lineHeight`: type `boolean`, default value `false`
+  - `textAlign`: type `boolean` or `array`, default value `false` _(added in 6.6)_
+  - `textColumns`: type `boolean`, default value `false` _(added in 6.1)_
+  - `textDecoration`: type `boolean`, default value `false` _(added in 6.1)_
+  - `textIndent`: type `boolean`, default value `false` _(added in 7.0)_
+  - `textTransform`: type `boolean`, default value `false` _(added in 6.1)_
+  - `writingMode`: type `boolean`, default value `false` _(added in 6.3)_
 
 The presence of this object signals that a block supports some typography related properties. When it does, the block editor will show a typography UI allowing the user to control their values.
 
 ```json
 "supports": {
     "typography": {
-        // Enable support and UI control for font-size.
-        "fontSize": true,
-        // Enable support and UI control for line-height.
-        "lineHeight": true,
-    },
+        "fontSize":       true,
+        "fontFamily":     true,
+        "fontStyle":      true,
+        "fontWeight":     true,
+        "letterSpacing":  true,
+        "lineHeight":     true,
+        "textAlign":      true,
+        "textColumns":    true,
+        "textDecoration": true,
+        "textIndent":     true,
+        "textTransform":  true,
+        "writingMode":    true
+    }
 }
 ```
+
+:::info
+`textAlign` also accepts an array to restrict which alignments are available, e.g. `"textAlign": [ "left", "center" ]`.
+:::
 
 ### typography.fontSize
 

--- a/reference/03-Blocks/block-updates.md
+++ b/reference/03-Blocks/block-updates.md
@@ -120,6 +120,23 @@ But be careful. Existing blocks on pages that don't get edited will still have t
 the `isEligible` check is required since the block editor would use the saved markup by default. But since we don't save our markup this is the way we can tell the editor what deprecation needs to run.
 :::
 
+## Block API versions
+
+Each block declares an `apiVersion` in its `block.json`. The version affects how the block is rendered in the editor (most notably whether it participates in the iframed editor).
+
+| API Version | Notable Behavior |
+| ----------- | ---------------- |
+| 1 | Legacy. Adds an extra wrapper `<div>` around block markup in the editor. |
+| 2 | Removes the extra wrapper, requires the use of `useBlockProps`. |
+| 3 | Block opts into the iframed editor and shares the same DOM as the saved markup. |
+
+:::warning WordPress 7.0
+Starting in WordPress 7.0, the **iframed editor is automatically enforced** when every block on the post uses Block API version 3 or higher. If even one block declares a lower API version, the editor falls back to the non-iframed renderer to maintain backwards compatibility.
+
+For most new client work this means setting `"apiVersion": 3` in `block.json` and making sure that scripts, fonts, and styles are loaded through the official enqueue APIs so they are forwarded into the iframe. Editor scripts that rely on `document` or `window` from the parent frame will need to be revisited.
+:::
+
 ## Further reading
 
 - [WordPress Block Deprecations Reference Guide](https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-deprecation.md)
+- [Block API Versions Reference](https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-api-versions.md)

--- a/reference/03-Blocks/block-variations.md
+++ b/reference/03-Blocks/block-variations.md
@@ -10,6 +10,10 @@ Block variations are a great way to surface one block in multiple ways. The best
 
 Variations can also be used in a variations picker to choose between different predefined setups of a block. This is how the core columns block creates its initial setup state where the editor can choose from a predefined list of different variations.
 
+:::tip WordPress 7.0
+In WordPress 7.0 the heading levels **H1–H6** are no longer registered as a single attribute toggle on `core/heading`. Each level is now registered as its own block variation. The variations are deliberately hidden from the inserter (`scope: ['transform']`) but show up in the toolbar transform picker and slash command — a useful pattern to mirror in your own design-system blocks where you want a single block class with multiple semantic variants.
+:::
+
 ![Core Columns Block initial setup state](../../static/img/block-variations-example.png)
 
 ## Using Block Variations

--- a/reference/03-Blocks/custom-blocks.md
+++ b/reference/03-Blocks/custom-blocks.md
@@ -88,3 +88,43 @@ Static blocks also only update when the post where they are used gets loaded in 
 :::info
 We recommend that any block that is meant to live on a site that is not directly maintained by a developer, or that is distributed through the plugin directory should use static rendering by default unless there are specific reasons dynamic rendering makes more sense for the specific use-case.
 :::
+
+### PHP-only Blocks (WordPress 7.0)
+
+:::caution Not recommended for client builds
+While PHP-only block registration removes the JavaScript build step, it does so by trading away the editorial experience. Because the editor UI is generated automatically from the attribute schema, every control ends up in the inspector sidebar — there is no inline editing with `RichText`, no live preview that matches the frontend, and no ability to surface controls in the block toolbar. The result feels much closer to a classic shortcode/widget than to a native block.
+
+For client work at 10up the recommendation is still to build dynamic blocks with a proper `edit` component so the editor sees what the visitor will see. Reserve `autoRegister` for purely administrative blocks where the visual representation in the editor genuinely does not matter.
+:::
+
+WordPress 7.0 introduces a new `autoRegister` block support that lets you register a fully working dynamic block **entirely in PHP** — no JavaScript build step required. The editor inspector for the block's attributes is generated automatically from the schema declared in `block.json`, and the block is exposed to the client via a JavaScript global so it still behaves like any other block in the inserter, list view, and DataForms.
+
+```json title="block.json"
+{
+    "apiVersion": 3,
+    "name": "namespace/php-only-block",
+    "title": "PHP Only Block",
+    "supports": {
+        "autoRegister": true
+    },
+    "attributes": {
+        "heading": {
+            "type": "string"
+        },
+        "ctaUrl": {
+            "type": "string"
+        }
+    },
+    "render": "file:./render.php"
+}
+```
+
+When `autoRegister` is set to `true`:
+
+- The block is registered server-side via `register_block_type()` as usual — the `render` callback is required.
+- WordPress automatically generates inspector controls for each supported attribute type.
+- The block is auto-exposed to the editor via a JS global, so no `index.js`/`registerBlockType()` call is needed.
+
+:::info
+PHP-only block registration is a great fit for simple data-driven blocks (latest posts, single-CPT renderers, server-side widgets) where the editor experience doesn't need a custom React UI. For inline-editable blocks with `RichText` we still recommend the standard dynamic block approach.
+:::

--- a/reference/04-Patterns/block-bindings-api.md
+++ b/reference/04-Patterns/block-bindings-api.md
@@ -6,7 +6,7 @@ sidebar_position: 4
 
 In WordPress 6.6 the [Block Bindings API](https://make.wordpress.org/core/2024/03/06/new-feature-the-block-bindings-api/) was introduced.  What this does is allow our blocks to read data from a variety of sources such as custom fields (post meta) or other logic created in php.  Under the hood, it is this feature that allows us to override our synced patterns.
 
-Again, it should be noted that only a handful of core blocks allow for this, and custom block support does not currently exist.  As of WordPress 6.6, the following blocks are enabled with the supported attributes listed after each one.
+Out of the box the following core blocks ship with built-in bindings support:
 
 | Supported Blocks | Supported Attributes |
 | ---------------- | ---------------------|
@@ -14,6 +14,20 @@ Again, it should be noted that only a handful of core blocks allow for this, and
 | Paragraph        | content              |
 | Heading	       | content              |
 | Button           | url, text, linkTarget, rel |
+
+:::tip WordPress 7.0
+Starting in WordPress 7.0, custom blocks can opt into the Block Bindings API (including Pattern Overrides) by registering attributes through the new `block_bindings_supported_attributes` filter. Any attribute exposed through this filter automatically becomes available for both custom binding sources and the built-in `core/pattern-overrides` source.
+
+```php
+add_filter(
+	'block_bindings_supported_attributes',
+	function ( $supported_attributes ) {
+		$supported_attributes['namespace/custom-block'] = array( 'title', 'subtitle', 'mediaId' );
+		return $supported_attributes;
+	}
+);
+```
+:::
 
 While the editor does not currently have an interface for applying these features, we can manually apply attributes to our block markup using the Code Editor view.  Let's run through an example using our Call to Action block from the previous entries on Synced Patterns.
 

--- a/reference/04-Patterns/synced-pattern-overrides.md
+++ b/reference/04-Patterns/synced-pattern-overrides.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 Editors now have the capability to maintain a Synced Pattern while being able to edit the content of the block on an individual basis.  In other words, we can keep the look and feel of our component in sync across the site, while being able to alter the text, links, or even images used within on a per use basis.
 
-It should be noted that only a handful of core blocks allow for this, and custom block support does not currently exist. As of WordPress 6.6, the following blocks are enabled with the supported attributes listed after each one.
+Out of the box the following core blocks support pattern overrides:
 
 | Supported Blocks | Supported Attributes |
 | ---------------- | ---------------------|
@@ -16,6 +16,22 @@ It should be noted that only a handful of core blocks allow for this, and custom
 | Button           | url, text, linkTarget, rel |
 
 In the case of our Call to Action pattern, we can override the Heading, Paragraph, and Button used *within*, but not overide the settings as a whole on the parent Group for example.
+
+:::tip WordPress 7.0
+WordPress 7.0 extends Pattern Overrides to **custom blocks**. Any attribute exposed via the `block_bindings_supported_attributes` filter is automatically available for the `core/pattern-overrides` source, so the bindings entry for a custom block looks identical to a core block:
+
+```php
+add_filter(
+	'block_bindings_supported_attributes',
+	function ( $supported_attributes ) {
+		$supported_attributes['namespace/cta'] = array( 'title', 'description', 'buttonUrl', 'buttonText' );
+		return $supported_attributes;
+	}
+);
+```
+
+7.0 also introduces pattern-level editing modes and the `disableContentOnlyForUnsyncedPatterns` setting (via the `block_editor_settings_all` filter) so you can opt individual patterns out of the new default content-only behavior. When you want a nested block inside a `contentOnly` pattern to remain editable, add `"role": "content"` to its attribute definition; declare `"supports": { "listView": true }` to surface the block in the pattern's list view for editors.
+:::
 
 :::caution
 When using Synced Pattern Overrides, it is very important to know that our blocks are not optional, and we cannot display them conditionally.


### PR DESCRIPTION
This pull request updates the documentation to cover new features and improvements introduced in WordPress 7.0, with a focus on block themes, the Interactivity API, and block supports. The most important changes are grouped below by theme.

**WordPress 7.0 Feature Additions and Updates**

* Added documentation for new block supports in `theme.json`, including `dimensions.height`, `dimensions.width`, and reusable size presets, as well as expanded color, background, and filter support. [[1]](diffhunk://#diff-5d0e0d134a63c6970663cb2b3370d3b024ef6150502955f30ac95250e4529519R164-R458) [[2]](diffhunk://#diff-97c5629b53585becb0db7d36c40f5f937c38def4b4cf0563a8b0de342e648414R99-R141) [[3]](diffhunk://#diff-97c5629b53585becb0db7d36c40f5f937c38def4b4cf0563a8b0de342e648414R168-R184) [[4]](diffhunk://#diff-97c5629b53585becb0db7d36c40f5f937c38def4b4cf0563a8b0de342e648414R441-R467) [[5]](diffhunk://#diff-97c5629b53585becb0db7d36c40f5f937c38def4b4cf0563a8b0de342e648414R500-R528)
* Updated guides to highlight the promotion of the Font Library to a dedicated admin page under Appearance → Fonts, now available for all themes, not just block themes.
* Added a new section on customizable navigation overlays for mobile menus, including overlay patterns and the new `core/navigation-overlay-close` block.
* Updated the Interactivity API guide to document new state change tools: the `watch()` function and the `data-wp-watch` directive, which simplify reacting to state/context changes in blocks.
* Added a note that `anchor` support is now fully available for dynamic blocks, with automatic UI and attribute handling for PHP-rendered blocks.

**Documentation and Reference Improvements**

* Expanded the schema version section in the `theme.json` reference to clarify the changes and migration notes for version 3.
* Added a link to the official WordPress 7.0 Field Guide for further reading.
* Updated block supports documentation to include new and expanded properties for color, background, block hooks, and filter/duotone controls. [[1]](diffhunk://#diff-97c5629b53585becb0db7d36c40f5f937c38def4b4cf0563a8b0de342e648414R99-R141) [[2]](diffhunk://#diff-97c5629b53585becb0db7d36c40f5f937c38def4b4cf0563a8b0de342e648414R168-R184) [[3]](diffhunk://#diff-97c5629b53585becb0db7d36c40f5f937c38def4b4cf0563a8b0de342e648414R441-R467) [[4]](diffhunk://#diff-97c5629b53585becb0db7d36c40f5f937c38def4b4cf0563a8b0de342e648414R500-R528)

**General Guide Updates**

* Updated introductory guides to recommend API Version 3 for new blocks in WordPress 7.0, clarifying the relationship between v2 and v3 requirements.

These updates ensure the documentation is current with the latest WordPress release, making it easier for developers to adopt new features and best practices.